### PR TITLE
add a way to install directly from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Or via pip::
 Pip may also be used to install a built package::
 
     $ pip install htmldiff-1.0.0.dev6.tar.gz
+    
+    
+To install without cloning/downloading the repository (requires Git installed)::
+
+    $ pip install git+https://github.com/danyill/htmldiff.git
 
 
 Usage


### PR DESCRIPTION
A lot of users are familiar with installing with `pip install <package>` which is not too far from `pip install git+https://github.com/<user>/<repo-name>.git`. Installing using local files is a bit scarier from my experience. I think adding installation directly from GitHub as an option will make it easier for some users.